### PR TITLE
fix(header): fix ButtonProps

### DIFF
--- a/apps/landing/src/components/Header/index.tsx
+++ b/apps/landing/src/components/Header/index.tsx
@@ -95,24 +95,26 @@ export const Header = () => {
             tabIndex={scrolled ? -1 : undefined}
           >
             <Button
-              href={siteConfig.links.github}
-              // target="_blank"
               size="sm"
               shape="square"
               variant="quiet"
               aria-label="github"
+              asChild
             >
-              <SiGithub />
+              <Link href={siteConfig.links.github} target="_blank">
+                <SiGithub />
+              </Link>
             </Button>
             <Button
-              href={siteConfig.links.twitter}
-              // target="_blank"
               size="sm"
               shape="square"
               variant="quiet"
               aria-label="twitter"
+              asChild
             >
-              <SiX />
+              <Link href={siteConfig.links.twitter} target="_blank">
+                <SiX />
+              </Link>
             </Button>
             <ThemeToggler />
           </div>
@@ -175,7 +177,6 @@ export const Header = () => {
     </header>
   );
 };
-
 
 // bg-zinc-800 dark:bg-zinc-200 text-white dark:text-zinc-900
 

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { tv, type VariantProps } from 'tailwind-variants';
-import { Loader2 } from 'lucide-react';
-import { focusRing } from '@gorlabs/utils';
 import { cn } from '@gorlabs/utils';
+// import { Loader2 } from 'lucide-react';
+import { focusRing } from '@gorlabs/utils';
 
 const buttonVariants = tv(
   {
@@ -77,53 +77,17 @@ interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
-  isLoading?: boolean;
-  prefix?: React.ReactNode;
-  suffix?: React.ReactNode;
-  href?: string; // Added href prop
 }
 
-const Button = React.forwardRef<
-  HTMLButtonElement & HTMLAnchorElement,
-  ButtonProps
->(
-  (
-    {
-      className,
-      variant,
-      size,
-      shape,
-      isLoading,
-      prefix,
-      suffix,
-      asChild,
-      href, // Destructure href prop
-      children,
-      ...props
-    },
-    ref
-  ) => {
-    const Component = asChild ? Slot : href ? 'a' : 'button'; // Render 'a' if href is present
-
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, shape, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
     return (
-      <Component
-        ref={ref}
+      <Comp
         className={cn(buttonVariants({ variant, size, shape, className }))}
-        href={href} // Add href if it's an anchor
-        target={href ? props.target : undefined} // Set target only for anchor
-        disabled={isLoading || props.disabled}
+        ref={ref}
         {...props}
-      >
-        {isLoading ? (
-          <Loader2 className="animate-spin" aria-label="loading" />
-        ) : (
-          <>
-            {prefix && <span className="mr-2">{prefix}</span>}
-            {children}
-            {suffix && <span className="ml-2">{suffix}</span>}
-          </>
-        )}
-      </Component>
+      />
     );
   }
 );


### PR DESCRIPTION
This pull request includes changes to the `Header` component in `apps/landing` and the `Button` component in `packages/ui` to improve code readability and maintainability. The most important changes involve refactoring the `Header` component to use the `Link` component and simplifying the `Button` component by removing unused props and imports.

### Header Component Refactor:
* [`apps/landing/src/components/Header/index.tsx`](diffhunk://#diff-ed10271f14c7d74876161d3a9f2e1dfe9b0f62e9a701182631581094e12583c0L98-R117): Refactored the `Button` elements for GitHub and Twitter links to use the `Link` component, ensuring proper handling of external links.
* [`apps/landing/src/components/Header/index.tsx`](diffhunk://#diff-ed10271f14c7d74876161d3a9f2e1dfe9b0f62e9a701182631581094e12583c0L179): Removed an unnecessary blank line for better code formatting.

### Button Component Simplification:
* [`packages/ui/src/components/Button/Button.tsx`](diffhunk://#diff-97973c54c2ac5270cf2d68e8f372365341693c8ae9d540ed62e0f614bfe92cf0L4-R6): Commented out unused imports to clean up the code.
* [`packages/ui/src/components/Button/Button.tsx`](diffhunk://#diff-97973c54c2ac5270cf2d68e8f372365341693c8ae9d540ed62e0f614bfe92cf0L80-R90): Removed unused props (`isLoading`, `prefix`, `suffix`, `href`) and simplified the `Button` component by eliminating conditional rendering based on these props.Fixed the Button.tsx and remove additional anchor checking