### PR TITLE
feat(mobile): added theme switcher in mobile view

### DIFF
--- a/apps/landing/src/components/Header/index.tsx
+++ b/apps/landing/src/components/Header/index.tsx
@@ -172,6 +172,7 @@ export const Header = () => {
           >
             <MenuIcon />
           </Button> */}
+          <ThemeToggler />
         </div>
       </div>
     </header>


### PR DESCRIPTION
This pull request includes a small change to the `apps/landing/src/components/Header/index.tsx` file. The change adds a `ThemeToggler` component to the `Header` component.

* [`apps/landing/src/components/Header/index.tsx`](diffhunk://#diff-ed10271f14c7d74876161d3a9f2e1dfe9b0f62e9a701182631581094e12583c0R175): Added `ThemeToggler` component to the `Header` component.