### PR TITLE
added selfhosted analytics

### DIFF
--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -8,6 +8,7 @@ import Particles from '@/components/Particles/Particles';
 import { siteConfig } from '@/config/site';
 import Metrics from '@/metrics';
 import { Header } from '@/components/Header';
+import Script from "next/script";
 
 const lexend = localFont({
   src: './fonts/Lexend-Regular.woff2',

--- a/apps/landing/src/app/layout.tsx
+++ b/apps/landing/src/app/layout.tsx
@@ -92,6 +92,10 @@ export default function RootLayout({
       <body
         className={`${lexend.variable} ${geistMono.variable} dark:bg-zinc-900`}
       >
+        <Script
+            defer
+            src="https://umami.gorlabs.com/script.js" data-website-id="98df0aeb-c3d4-471a-80dc-5baa067d28cf"
+          />
         <Metrics />
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
           {/* <Navbar /> */}


### PR DESCRIPTION
This pull request includes changes to the `apps/landing/src/app/layout.tsx` file to add a new script for analytics tracking and improve the layout configuration.

### Improvements to layout configuration:

* [`apps/landing/src/app/layout.tsx`](diffhunk://#diff-e6207283525288fd37de89b0c06da36346263d0e7c4f1587b2f1a587d3586b7dR11): Added an import for `Script` from `next/script` to enable script usage in the layout.
* [`apps/landing/src/app/layout.tsx`](diffhunk://#diff-e6207283525288fd37de89b0c06da36346263d0e7c4f1587b2f1a587d3586b7dR96-R99): Added a new `Script` component within the `RootLayout` function to defer loading of an external analytics script from "umami.gorlabs.com" with a specified `data-website-id`.