### PR TITLE
fix(web): update edge runtime

### DIFF
--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -1,4 +1,4 @@
-export const runtime = 'edge';
+// export const runtime = 'edge';
 
 import { showBetaFeature } from '@repo/feature-flags';
 import { createMetadata } from '@repo/seo/metadata';

--- a/apps/web/app/blog/[slug]/page.tsx
+++ b/apps/web/app/blog/[slug]/page.tsx
@@ -145,7 +145,7 @@
 // };
 
 // export default BlogPost;
-export const runtime = 'edge';
+// export const runtime = 'edge';
 import React from 'react'
 
 const BlogPost = () => {

--- a/apps/web/app/legal/[slug]/page.tsx
+++ b/apps/web/app/legal/[slug]/page.tsx
@@ -93,7 +93,7 @@
 
 // export default LegalPage;
 
-export const runtime = 'edge';
+// export const runtime = 'edge';
 
 import React from 'react'
 


### PR DESCRIPTION
This pull request includes changes to comment out the `runtime` export in multiple files. This is likely done to disable edge runtime for these pages temporarily.

Changes include:

* [`apps/web/app/(home)/page.tsx`](diffhunk://#diff-0cef2e3cfe9e327dd64ef6b7ce82ce6e4dcc9f50cc423e8d28e37c1d926841a8L1-R1): Commented out the `runtime` export.
* `apps/web/app/blog/[slug]/page.tsx`: Commented out the `runtime` export. ([apps/web/app/blog/[slug]/page.tsxL148-R148](diffhunk://#diff-1ab791143807ed207450a994a8935468828b6a8eedde8da0985179da0b470dc9L148-R148))
* `apps/web/app/legal/[slug]/page.tsx`: Commented out the `runtime` export. ([apps/web/app/legal/[slug]/page.tsxL96-R96](diffhunk://#diff-b4da37b3f013c0c4d9ac98df1289535aaad2301a8b70d04086815160d20e9da2L96-R96))