### PR TITLE
fix(docs): added Node 18 compat

### DIFF
--- a/apps/docs/wrangler.toml
+++ b/apps/docs/wrangler.toml
@@ -1,0 +1,14 @@
+name = "docs"
+compatibility_date = "2024-11-12"
+compatibility_flags = [ "nodejs_compat" ]
+pages_build_output_dir = ".vercel/output/static"
+
+[placement]
+mode = "smart"
+
+[vars]
+NODE_VERSION = "18.18.0"
+
+# [observability]
+# enabled = true
+# head_sampling_rate = 1


### PR DESCRIPTION
This pull request includes a configuration update for the `apps/docs/wrangler.toml` file to set up the environment for the documentation site. The most important changes include specifying the compatibility date and flags, setting the build output directory, and defining environment variables.

Configuration updates:

* [`apps/docs/wrangler.toml`](diffhunk://#diff-20e9147529edd042d4c6e62b8e7d7068e2702f973429e0a8a2a5782bd4de1b86R1-R14): Added `name`, `compatibility_date`, `compatibility_flags`, `pages_build_output_dir`, and environment variable `NODE_VERSION`.