### PR TITLE
fix(docs): fix runtime conflicts

### DIFF
--- a/apps/docs/src/app/(docs)/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/(docs)/[[...slug]]/page.tsx
@@ -1,4 +1,3 @@
-export const runtime = 'edge';
 import { source } from '@/lib/source';
 import {
   DocsPage,

--- a/apps/docs/src/app/(docs)/layout.tsx
+++ b/apps/docs/src/app/(docs)/layout.tsx
@@ -1,3 +1,4 @@
+export const runtime = 'edge';
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import type { ReactNode } from 'react';
 import { baseOptions } from '@/app/layout.config';


### PR DESCRIPTION
This pull request includes changes to the `runtime` export in the `apps/docs` directory. The most important changes include moving the `runtime` export from `page.tsx` to `layout.tsx`.

Changes to `runtime` export:

* `apps/docs/src/app/(docs)/[[...slug]]/page.tsx`: Removed the `runtime` export. ([apps/docs/src/app/(docs)/[[...slug]]/page.tsxL1](diffhunk://#diff-0b71562b130c2c82ba6bd3d34c6ef4695cd294bfd2248b9c0491101a244e8cd8L1))
* [`apps/docs/src/app/(docs)/layout.tsx`](diffhunk://#diff-8f1769b3a2624c3826107dba3bce9a122878ae3a4126ededd7a0de30a55a1454R1): Added the `runtime` export.