### PR TITLE
fix(web): patch font 2

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -27,7 +27,7 @@ type RootLayoutProperties = {
 const RootLayout = ({ children }: RootLayoutProperties) => (
   <html
     lang="en"
-    className={cn(Apparat.className, fonts, 'scroll-smooth')}
+    className={cn(Apparat.className, 'scroll-smooth')}
     suppressHydrationWarning
   >
     <body>


### PR DESCRIPTION
This pull request includes a small change to the `apps/web/app/layout.tsx` file. The change removes the `fonts` class from the `className` attribute in the `RootLayout` component.

* [`apps/web/app/layout.tsx`](diffhunk://#diff-c235c52626fe2cfbb53241bb015bdd7b5f5a28f9a10a08e1f401238e773fa7adL30-R30): Removed the `fonts` class from the `className` attribute in the `RootLayout` component.